### PR TITLE
[GPF-217] Fix firefox crash

### DIFF
--- a/apps/frontend/src/components/TaskList/DecisionNode/DecisionNode.module.scss
+++ b/apps/frontend/src/components/TaskList/DecisionNode/DecisionNode.module.scss
@@ -26,6 +26,7 @@
 	position: relative;
 	z-index: 0;
 	cursor: pointer;
+	scroll-margin: 200px 0;
 
 	span {
 		user-select: none;

--- a/apps/frontend/src/components/TaskList/TaskNode/TaskNode.module.scss
+++ b/apps/frontend/src/components/TaskList/TaskNode/TaskNode.module.scss
@@ -16,7 +16,7 @@
 	transition-property: background-color, color, border-color;
 	transition: background-color 0.15s ease-out;
 	cursor: pointer;
-	scroll-margin: 1rem;
+	scroll-margin: 200px 0;
 
 	input {
 		display: none;

--- a/apps/frontend/src/pages/Gruendung/$task.tsx
+++ b/apps/frontend/src/pages/Gruendung/$task.tsx
@@ -62,10 +62,7 @@ const Gruendung_TaskId = () => {
 	useEffect(() => {
 		setMarkDownComponent();
 
-		document
-			.querySelector(`[data-id="${task}"]`)
-			// @ts-ignoreest 5
-			?.scrollIntoViewIfNeeded(false);
+		document.querySelector(`[data-id="${task}"]`)?.scrollIntoView(false);
 	}, [task, currentCompany]);
 
 	return (


### PR DESCRIPTION
Closes: [GPF-217](https://spacifik.atlassian.net/jira/software/projects/GPF/boards/3?selectedIssue=GPF-217)

Firefox crashed because scrollintoviewifneeded isn't supported.

This fixes it and adds a scroll margin, so you can see the element after the one you selected.