### PR TITLE
[GPF-250] Log In notice for DLR profile

### DIFF
--- a/apps/frontend/src/components/Menu/Menu.tsx
+++ b/apps/frontend/src/components/Menu/Menu.tsx
@@ -33,7 +33,7 @@ const Menu: FC<MenuProps> = ({ isLoggedIn, isAdmin, closeMenu }) => {
 			)}
 			<div className={styles.dropdownItemWrapper}>
 				<Link
-					to='/profil/diensleister'
+					to='/profil/dienstleister'
 					className={styles.dropdownItem}
 					onClick={closeMenu}
 				>

--- a/apps/frontend/src/pages/Profil/Profil.module.scss
+++ b/apps/frontend/src/pages/Profil/Profil.module.scss
@@ -75,3 +75,30 @@
 		}
 	}
 }
+
+.logInMessageWrapper {
+	width: 100%;
+	min-height: 100%;
+	padding-bottom: 150px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	@media (max-width: 950px) {
+		padding-bottom: 100px;
+	}
+
+	.logInMessageContainer {
+		width: 90%;
+
+		p {
+			text-align: center;
+			font-weight: var(--font-weight-bold);
+		}
+
+		.authWrapper {
+			margin: 3rem auto 0 auto;
+			width: fit-content;
+		}
+	}
+}

--- a/apps/frontend/src/pages/Profil/Profil.tsx
+++ b/apps/frontend/src/pages/Profil/Profil.tsx
@@ -4,14 +4,42 @@ import { useState } from "react";
 import BackArrow from "@vc/frontend/component/BackArrow/BackArrow";
 import { Link, useParams } from "react-router-dom";
 import DienstleisterProfil from "./subcomponents/DienstleisterProfil";
+import { useAuthContext } from "@vc/auth/src/AuthContext";
+/* import { AuthUI } from "@vc/auth"; */
 
 export interface ProfileParams {
 	platform: string;
 }
 
 export default function () {
+	const { user: currentUser } = useAuthContext();
 	const { platform } = useParams<ProfileParams>();
 	const [GPF_DLR, switchProfile] = useState(platform);
+
+	if (!currentUser && GPF_DLR == "dienstleister") {
+		return (
+			<div
+				style={{
+					minHeight: "100%",
+					display: "flex",
+					justifyContent: "center",
+					background:
+						"radial-gradient(95.33% 88.77% at 100% 25.99%, #F3EAE4 0%, #F5EBDF 11.12%, #F6F5F8 33.47%)",
+					overflowY: "scroll",
+				}}
+				className={s.profilContainer}
+			>
+				<div className={s.logInMessageWrapper}>
+					<div className={s.logInMessageContainer}>
+						<p>Jetzt anmelden, um dich als Dienstleister zu registrieren</p>
+						{/* <div className={s.authWrapper}>
+							<AuthUI />
+						</div> */}
+					</div>
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div

--- a/apps/frontend/src/pages/Profil/subcomponents/DienstleisterProfil.tsx
+++ b/apps/frontend/src/pages/Profil/subcomponents/DienstleisterProfil.tsx
@@ -18,7 +18,9 @@ export default function DienstleisterProfil() {
 	async function getDienstleisterOfUser() {
 		let idTokenResult = await user?.getIdTokenResult();
 
-		if (idTokenResult?.claims.role == "user") {
+		if (idTokenResult?.claims.role == "admin") {
+			setIsAdmin(true);
+		} else {
 			setIsAdmin(false);
 			const requestOptions = {
 				method: "GET",
@@ -33,30 +35,28 @@ export default function DienstleisterProfil() {
 			} else {
 				setDienstleisterOfUser("");
 			}
-		} else {
-			setIsAdmin(true);
 		}
 	}
 
-	if (isAdmin === false) {
-		if (dienstleisterOfUser == "") {
-			return (
-				<CreateDienstleister getDienstleisterOfUser={getDienstleisterOfUser} />
-			);
-		} else {
-			return (
-				<EditDeleteDienstleister
-					dienstleisterOfUser={dienstleisterOfUser}
-					getDienstleisterOfUser={getDienstleisterOfUser}
-				/>
-			);
-		}
-	} else {
+	if (isAdmin) {
 		return (
 			<p>
 				Hey, du bist Admin, wenn du eine Firma anlegen willst, musst du das über
 				das <Link to='/dienstleister/admin'>Admin Panel</Link> machen.
 			</p>
+		);
+	}
+
+	if (dienstleisterOfUser == "") {
+		return (
+			<CreateDienstleister getDienstleisterOfUser={getDienstleisterOfUser} />
+		);
+	} else {
+		return (
+			<EditDeleteDienstleister
+				dienstleisterOfUser={dienstleisterOfUser}
+				getDienstleisterOfUser={getDienstleisterOfUser}
+			/>
 		);
 	}
 }


### PR DESCRIPTION
Closes: [GPF-250](https://spacifik.atlassian.net/jira/software/projects/GPF/boards/3?selectedIssue=GPF-250)

## Comments
Its not possible to have two “Sign in with Google”-Buttons showing at the same time, thats why there is only one line of text.
I still left the code for the “Sign in with Google”-Button in it, but commented it out. Style would also be good with the button, if we add the support for that @konstantin-spiess.
It looks a bit odd with just the one line of text, we probably should add something, maybe an arrow to the log in button in the header or something else. Im open for suggestions.
Note: I only block the `http://localhost:8100/profil/dienstleister` site, not the `http://localhost:8100/profil/gruender` site which still would be shown if you type in the url and are not logged in.
## Changes

- fixed the menu Link to dienstleister profile
- added the log in notice if you are not logged in, but want to create a dienstleister
- refactored profile logic