### PR TITLE
[GPF-258/243/238/269]

### DIFF
--- a/apps/frontend/src/pages/Adminpanel/Adminpanel.module.scss
+++ b/apps/frontend/src/pages/Adminpanel/Adminpanel.module.scss
@@ -57,6 +57,7 @@ input:focus {
 	padding: 0;
 	padding: 2px 4px 2px 0px;
 	margin: 8px 20px 4px 0px;
+	background-color: transparent;
 }
 
 .verifiedoption:focus {

--- a/apps/frontend/src/pages/Adminpanel/Adminpanel.tsx
+++ b/apps/frontend/src/pages/Adminpanel/Adminpanel.tsx
@@ -1,5 +1,5 @@
 import s from "./Adminpanel.module.scss";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Button from "@vc/ui/src/components/Button/Button";
 import GetAllResultList from "./subcomponents/GetAllResultList/GetAllResultList";
 import CreateFormAdmin from "./subcomponents/CreateFormAdmin/CreateFormAdmin";
@@ -11,6 +11,7 @@ export default function Adminpanel() {
 	const [loadedPages, setLoadedPages] = useState<any>([]);
 
 	const { user } = useAuthContext();
+	const [isAdmin, setIsAdmin] = useState(false);
 	// Filter Companies by verified status
 	const [chosenVerified, setChosenVerified] = useState("Alle");
 	const [currentPage, setCurrentPage] = useState(0);
@@ -20,6 +21,20 @@ export default function Adminpanel() {
 
 	// needed to get data of one concrete search result to the editform located here
 	const [editData, setEditData] = useState();
+
+	useEffect(() => {
+		checkAdmin();
+	}, [user]);
+
+	async function checkAdmin() {
+		let idTokenResult = await user?.getIdTokenResult();
+
+		if (idTokenResult?.claims.role == "admin") {
+			setIsAdmin(true);
+		} else {
+			setIsAdmin(false);
+		}
+	}
 
 	async function startGetAllRequest(event: any) {
 		event.preventDefault();
@@ -99,6 +114,9 @@ export default function Adminpanel() {
 		}
 	}
 
+	if (isAdmin === false) {
+		return <></>;
+	}
 	if (currentlyCreating === true) {
 		return (
 			<CreateFormAdmin

--- a/apps/frontend/src/pages/Adminpanel/subcomponents/CreateFormAdmin/CreateFormAdmin.module.scss
+++ b/apps/frontend/src/pages/Adminpanel/subcomponents/CreateFormAdmin/CreateFormAdmin.module.scss
@@ -77,6 +77,7 @@ input:focus {
 	font-size: var(--size-18px);
 	padding: 2px 4px 2px 0px;
 	margin: 12px 20px 4px 0px;
+	background-color: transparent;
 }
 
 .divforthatAdmin {

--- a/apps/frontend/src/pages/Adminpanel/subcomponents/EditFormAdmin/EditFormAdmin.module.scss
+++ b/apps/frontend/src/pages/Adminpanel/subcomponents/EditFormAdmin/EditFormAdmin.module.scss
@@ -67,6 +67,7 @@ input:focus {
 	font-size: var(--size-18px);
 	padding: 2px 4px 2px 0px;
 	margin: 12px 20px 4px 0px;
+	background-color: transparent;
 }
 
 .divforthatEditAdmin {

--- a/apps/frontend/src/pages/SearchDLR/subcomponents/PaginationDLR/Pagination.tsx
+++ b/apps/frontend/src/pages/SearchDLR/subcomponents/PaginationDLR/Pagination.tsx
@@ -11,27 +11,31 @@ interface Props {
 const Pagination = ({ page, loadedPages, weiter, zurueck }: Props) => {
 	return (
 		<>
-			<div className={s.pagination}>
-				{page > 1 ? (
-					<div onClick={zurueck} className={s.enabled}>
-						<Button>{"< "}Zurück</Button>
-					</div>
-				) : (
-					<div>
-						<button className={s.disabled}>{"< "} Zurück</button>
-					</div>
-				)}
+			{loadedPages.length > 1 && loadedPages[1]?.length > 0 ? (
+				<div className={s.pagination}>
+					{page > 1 ? (
+						<div onClick={zurueck} className={s.enabled}>
+							<Button>{"< "}Zurück</Button>
+						</div>
+					) : (
+						<div>
+							<button className={s.disabled}>{"< "} Zurück</button>
+						</div>
+					)}
 
-				{loadedPages[page]?.length > 0 ? (
-					<div onClick={e => weiter()} className={s.enabled}>
-						<Button>Weiter {" >"}</Button>
-					</div>
-				) : (
-					<div>
-						<button className={s.disabled}>Weiter {" >"}</button>
-					</div>
-				)}
-			</div>
+					{loadedPages[page]?.length > 0 ? (
+						<div onClick={e => weiter()} className={s.enabled}>
+							<Button>Weiter {" >"}</Button>
+						</div>
+					) : (
+						<div>
+							<button className={s.disabled}>Weiter {" >"}</button>
+						</div>
+					)}
+				</div>
+			) : (
+				<></>
+			)}
 		</>
 	);
 };

--- a/apps/frontend/src/pages/SearchDLR/subcomponents/SearchFormDLR/SearchForm.module.scss
+++ b/apps/frontend/src/pages/SearchDLR/subcomponents/SearchFormDLR/SearchForm.module.scss
@@ -31,6 +31,7 @@ input:focus {
 	padding: 0;
 	padding: 2px 4px 2px 0px;
 	margin: 12px 20px 4px 0px;
+	background-color: transparent;
 }
 
 .joboption:focus {

--- a/apps/frontend/src/pages/SearchDLR/subcomponents/SearchResultsListDLR/SearchResult.module.scss
+++ b/apps/frontend/src/pages/SearchDLR/subcomponents/SearchResultsListDLR/SearchResult.module.scss
@@ -6,6 +6,7 @@
 	border-radius: 10px;
 	border-width: 1px;
 	background-color: #fff;
+	cursor: pointer;
 
 	flex: 1 0 20em;
 }
@@ -62,5 +63,4 @@
 	font-weight: bold;
 	text-decoration: underline;
 	font-size: var(--size-16px);
-	cursor: pointer;
 }

--- a/apps/frontend/src/pages/SearchDLR/subcomponents/SearchResultsListDLR/SearchResult.tsx
+++ b/apps/frontend/src/pages/SearchDLR/subcomponents/SearchResultsListDLR/SearchResult.tsx
@@ -100,7 +100,7 @@ const SearchResult = ({ resultData }: Props) => {
 	}
 
 	return (
-		<div className={s.resultframe}>
+		<div className={s.resultframe} onClick={e => openMoreInfo()}>
 			<p className={s.result_company}>{resultData.company}</p>
 			<p className={s.result_job}>{resultData.job}</p>
 			<br></br>
@@ -111,9 +111,7 @@ const SearchResult = ({ resultData }: Props) => {
 			<br></br>
 			{checkDescription()}
 			<br></br>
-			<p className={s.result_moreinfo} onClick={e => openMoreInfo()}>
-				Mehr Informationen
-			</p>
+			<p className={s.result_moreinfo}>Mehr Informationen</p>
 			{checkDialog()}
 		</div>
 	);


### PR DESCRIPTION
Closes: [GPF-258](https://spacifik.atlassian.net/jira/software/projects/GPF/boards/3?assignee=70121%3A5f7ba5dc-bbe1-4abd-9436-b8dc3ec94ec1&selectedIssue=GPF-258) [GPF-243](https://spacifik.atlassian.net/jira/software/projects/GPF/boards/3?assignee=70121%3A5f7ba5dc-bbe1-4abd-9436-b8dc3ec94ec1&selectedIssue=GPF-243) [GPF-238](https://spacifik.atlassian.net/jira/software/projects/GPF/boards/3?assignee=70121%3A5f7ba5dc-bbe1-4abd-9436-b8dc3ec94ec1&selectedIssue=GPF-238) [GPF-269](https://spacifik.atlassian.net/jira/software/projects/GPF/boards/3?assignee=70121%3A5f7ba5dc-bbe1-4abd-9436-b8dc3ec94ec1&selectedIssue=GPF-269)

## Comments

## Changes
- Bei den öffentlichen Suchergebnissen ist nun die ganze Kachel klickbar
- Der Hintergrund der Select-Dropdowns ist jetzt browserübergreifend transparent gesetzt
- Unangemeldete o. nicht-Admin Nutzer bekommen nun korrekterweise eine Seite mit nur dem Header angezeigt wenn sie auf das Adminpanel gehen, statt dem normalen, wenn auch funktionsfreiem, Adminpanel
- In der öffentlichen Suche werden keine Pagination-Komponenten angezeigt wenn es nur eine Ergebnisseite gibt.
