### PR TITLE
[GPF-242] Loading components DLR-Search & DLR-Profile

### DIFF
--- a/apps/frontend/src/pages/Profil/subcomponents/DienstleisterProfil.module.scss
+++ b/apps/frontend/src/pages/Profil/subcomponents/DienstleisterProfil.module.scss
@@ -1,0 +1,79 @@
+.loadingIndicator {
+	margin: 4rem auto 0;
+	position: relative;
+	width: 80px;
+	height: 0px;
+	transform: scale(0.8);
+	animation: scaleUp 0.4s ease-in-out;
+	animation-delay: 0.4s;
+	opacity: 0;
+	animation-fill-mode: forwards;
+}
+
+@keyframes scaleUp {
+	from {
+		height: 0;
+		opacity: 0;
+	}
+	to {
+		height: 13px;
+		opacity: 1;
+	}
+}
+
+.loadingIndicator div {
+	position: absolute;
+	top: 0px;
+	width: 13px;
+	height: 13px;
+	border-radius: 50%;
+	background: var(--color-grey-900);
+	animation-timing-function: cubic-bezier(0, 1, 1, 0);
+}
+
+.loadingIndicator div:nth-child(1) {
+	left: 8px;
+	animation: lds-ellipsis1 0.6s infinite;
+}
+
+.loadingIndicator div:nth-child(2) {
+	left: 8px;
+	animation: lds-ellipsis2 0.6s infinite;
+}
+
+.loadingIndicator div:nth-child(3) {
+	left: 32px;
+	animation: lds-ellipsis2 0.6s infinite;
+}
+
+.loadingIndicator div:nth-child(4) {
+	left: 56px;
+	animation: lds-ellipsis3 0.6s infinite;
+}
+
+@keyframes lds-ellipsis1 {
+	0% {
+		transform: scale(0);
+	}
+	100% {
+		transform: scale(1);
+	}
+}
+
+@keyframes lds-ellipsis3 {
+	0% {
+		transform: scale(1);
+	}
+	100% {
+		transform: scale(0);
+	}
+}
+
+@keyframes lds-ellipsis2 {
+	0% {
+		transform: translate(0, 0);
+	}
+	100% {
+		transform: translate(24px, 0);
+	}
+}

--- a/apps/frontend/src/pages/Profil/subcomponents/DienstleisterProfil.tsx
+++ b/apps/frontend/src/pages/Profil/subcomponents/DienstleisterProfil.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useAuthContext } from "@vc/auth/src/AuthContext";
+import s from "./DienstleisterProfil.module.scss";
 
 import CreateDienstleister from "./CreateDienstleister";
 import EditDeleteDienstleister from "./EditDeleteDienstleister";
@@ -8,10 +9,14 @@ import { Link } from "react-router-dom";
 export default function DienstleisterProfil() {
 	const { user } = useAuthContext();
 
+	const [loadingState, setLoadingState] = useState<
+		undefined | "loading" | "finished" | "error"
+	>();
 	const [dienstleisterOfUser, setDienstleisterOfUser] = useState("");
 	const [isAdmin, setIsAdmin] = useState(false);
 
 	useEffect(() => {
+		setLoadingState("loading");
 		getDienstleisterOfUser();
 	}, [user || dienstleisterOfUser === ""]);
 
@@ -36,21 +41,33 @@ export default function DienstleisterProfil() {
 		} else {
 			setIsAdmin(true);
 		}
+		setLoadingState("finished");
 	}
 
 	if (isAdmin === false) {
-		if (dienstleisterOfUser == "") {
-			return (
-				<CreateDienstleister getDienstleisterOfUser={getDienstleisterOfUser} />
-			);
-		} else {
-			return (
-				<EditDeleteDienstleister
-					dienstleisterOfUser={dienstleisterOfUser}
-					getDienstleisterOfUser={getDienstleisterOfUser}
-				/>
-			);
-		}
+		return (
+			<>
+				{loadingState == "loading" && (
+					<div className={s.loadingIndicator}>
+						<div></div>
+						<div></div>
+						<div></div>
+						<div></div>
+					</div>
+				)}
+				{loadingState == "finished" && dienstleisterOfUser == "" && (
+					<CreateDienstleister
+						getDienstleisterOfUser={getDienstleisterOfUser}
+					/>
+				)}
+				{loadingState == "finished" && dienstleisterOfUser != "" && (
+					<EditDeleteDienstleister
+						dienstleisterOfUser={dienstleisterOfUser}
+						getDienstleisterOfUser={getDienstleisterOfUser}
+					/>
+				)}
+			</>
+		);
 	} else {
 		return (
 			<p>

--- a/apps/frontend/src/pages/SearchDLR/DLRSearch.module.scss
+++ b/apps/frontend/src/pages/SearchDLR/DLRSearch.module.scss
@@ -26,3 +26,83 @@
 		font-size: var(--size-18px);
 	}
 }
+
+.loadingIndicator {
+	margin: 3rem auto 0;
+	position: relative;
+	width: 80px;
+	height: 0px;
+	transform: scale(0.8);
+	animation: scaleUp 0.4s ease-in-out;
+	animation-delay: 0.2s;
+	opacity: 0;
+	animation-fill-mode: forwards;
+}
+
+@keyframes scaleUp {
+	from {
+		height: 0;
+		opacity: 0;
+	}
+	to {
+		height: 13px;
+		opacity: 1;
+	}
+}
+
+.loadingIndicator div {
+	position: absolute;
+	top: 0px;
+	width: 13px;
+	height: 13px;
+	border-radius: 50%;
+	background: var(--color-grey-900);
+	animation-timing-function: cubic-bezier(0, 1, 1, 0);
+}
+
+.loadingIndicator div:nth-child(1) {
+	left: 8px;
+	animation: lds-ellipsis1 0.6s infinite;
+}
+
+.loadingIndicator div:nth-child(2) {
+	left: 8px;
+	animation: lds-ellipsis2 0.6s infinite;
+}
+
+.loadingIndicator div:nth-child(3) {
+	left: 32px;
+	animation: lds-ellipsis2 0.6s infinite;
+}
+
+.loadingIndicator div:nth-child(4) {
+	left: 56px;
+	animation: lds-ellipsis3 0.6s infinite;
+}
+
+@keyframes lds-ellipsis1 {
+	0% {
+		transform: scale(0);
+	}
+	100% {
+		transform: scale(1);
+	}
+}
+
+@keyframes lds-ellipsis3 {
+	0% {
+		transform: scale(1);
+	}
+	100% {
+		transform: scale(0);
+	}
+}
+
+@keyframes lds-ellipsis2 {
+	0% {
+		transform: translate(0, 0);
+	}
+	100% {
+		transform: translate(24px, 0);
+	}
+}

--- a/apps/frontend/src/pages/SearchDLR/DLRSearch.module.scss
+++ b/apps/frontend/src/pages/SearchDLR/DLRSearch.module.scss
@@ -28,13 +28,13 @@
 }
 
 .loadingIndicator {
-	margin: 3rem auto 0;
+	margin: 4rem auto 0;
 	position: relative;
 	width: 80px;
 	height: 0px;
 	transform: scale(0.8);
 	animation: scaleUp 0.4s ease-in-out;
-	animation-delay: 0.2s;
+	animation-delay: 0s;
 	opacity: 0;
 	animation-fill-mode: forwards;
 }

--- a/apps/frontend/src/pages/SearchDLR/DLRSearch.tsx
+++ b/apps/frontend/src/pages/SearchDLR/DLRSearch.tsx
@@ -8,7 +8,7 @@ import React, { useState } from "react";
 export default function DLRSearch() {
 	const [loadedPages, setLoadedPages] = useState<any>([]);
 	const [loadingState, setLoadingState] = useState<
-		undefined | "loading" | "error"
+		undefined | "loading" | "finished" | "error"
 	>();
 	const [chosenJob, setChosenJob] = useState("");
 	const [displayJob, setDisplayJob] = useState("");
@@ -27,7 +27,7 @@ export default function DLRSearch() {
 
 		setLoadedPages([pageOne, pageTwo]);
 		setCurrentPage(1);
-		setLoadingState(undefined);
+		setLoadingState("finished");
 	}
 
 	async function weiter() {
@@ -52,7 +52,22 @@ export default function DLRSearch() {
 		return fetchData.json();
 	}
 
-	if (loadedPages.length > 0) {
+	if (loadingState == undefined) {
+		return (
+			<div className={s.wrapper}>
+				<Headline />
+				<SearchForm
+					startSearchRequest={startSearchRequest}
+					chosenJob={chosenJob}
+					setChosenJob={setChosenJob}
+					setChosenAddress={setChosenAddress}
+					lat={lat}
+					setLat={setLat}
+					setLong={setLong}
+				/>
+			</div>
+		);
+	} else {
 		return (
 			<div className={s.wrapper}>
 				<Headline />
@@ -71,28 +86,6 @@ export default function DLRSearch() {
 						<span className={s.greenSpan}>{displayAddress}</span>
 					</p>
 				</div>
-				<SearchResultsList searchResponse={loadedPages[currentPage - 1]} />
-				<Pagination
-					page={currentPage}
-					loadedPages={loadedPages}
-					weiter={weiter}
-					zurueck={() => setCurrentPage(currentPage - 1)}
-				/>
-			</div>
-		);
-	} else {
-		return (
-			<div className={s.wrapper}>
-				<Headline />
-				<SearchForm
-					startSearchRequest={startSearchRequest}
-					chosenJob={chosenJob}
-					setChosenJob={setChosenJob}
-					setChosenAddress={setChosenAddress}
-					lat={lat}
-					setLat={setLat}
-					setLong={setLong}
-				/>
 				{loadingState == "loading" && (
 					<div className={s.loadingIndicator}>
 						<div></div>
@@ -100,6 +93,17 @@ export default function DLRSearch() {
 						<div></div>
 						<div></div>
 					</div>
+				)}
+				{loadingState == "finished" && (
+					<>
+						<SearchResultsList searchResponse={loadedPages[currentPage - 1]} />
+						<Pagination
+							page={currentPage}
+							loadedPages={loadedPages}
+							weiter={weiter}
+							zurueck={() => setCurrentPage(currentPage - 1)}
+						/>
+					</>
 				)}
 			</div>
 		);

--- a/apps/frontend/src/pages/SearchDLR/DLRSearch.tsx
+++ b/apps/frontend/src/pages/SearchDLR/DLRSearch.tsx
@@ -7,7 +7,9 @@ import React, { useState } from "react";
 
 export default function DLRSearch() {
 	const [loadedPages, setLoadedPages] = useState<any>([]);
-
+	const [loadingState, setLoadingState] = useState<
+		undefined | "loading" | "error"
+	>();
 	const [chosenJob, setChosenJob] = useState("");
 	const [displayJob, setDisplayJob] = useState("");
 	const [chosenAddress, setChosenAddress] = useState("");
@@ -19,11 +21,13 @@ export default function DLRSearch() {
 	async function startSearchRequest() {
 		setDisplayJob(chosenJob);
 		setDisplayAddress(chosenAddress);
+		setLoadingState("loading");
 		let pageOne = await getSearchResult(1);
 		let pageTwo = await getSearchResult(2);
 
 		setLoadedPages([pageOne, pageTwo]);
 		setCurrentPage(1);
+		setLoadingState(undefined);
 	}
 
 	async function weiter() {
@@ -50,7 +54,7 @@ export default function DLRSearch() {
 
 	if (loadedPages.length > 0) {
 		return (
-			<>
+			<div className={s.wrapper}>
 				<Headline />
 				<SearchForm
 					startSearchRequest={startSearchRequest}
@@ -74,7 +78,7 @@ export default function DLRSearch() {
 					weiter={weiter}
 					zurueck={() => setCurrentPage(currentPage - 1)}
 				/>
-			</>
+			</div>
 		);
 	} else {
 		return (
@@ -89,6 +93,14 @@ export default function DLRSearch() {
 					setLat={setLat}
 					setLong={setLong}
 				/>
+				{loadingState == "loading" && (
+					<div className={s.loadingIndicator}>
+						<div></div>
+						<div></div>
+						<div></div>
+						<div></div>
+					</div>
+				)}
 			</div>
 		);
 	}


### PR DESCRIPTION
Closes: [GPF-242](https://spacifik.atlassian.net/jira/software/projects/GPF/boards/3?selectedIssue=GPF-242)

## Comments
Added the loading components for DLR-Search and for opening the DLR-Profile Page.
I dont think we need loading components for creating and deleting the Dienstleister due to the fact that most of the time there is no coldstart when doing that. What do you think about that? Should we add those anyway?
I also fixed the background and address deleted on first search bug for DLR-Search. ([GPF-282](https://spacifik.atlassian.net/jira/software/projects/GPF/boards/3?selectedIssue=GPF-282))
Still another bug left which I was not able to fix. It has something to do with out font.
But its probably not necessary to fix it, if @kai-konitzer will change the design anyways.

## Changes

- Added Loading component for DLR-Search
- Minor Bug fixes DLR-Search
- Added Loading component for DLR-Profile when opening the site