### PR TITLE
GPF-287 Inputtypen optimieren

### DIFF
--- a/apps/frontend/src/pages/Adminpanel/subcomponents/CreateFormAdmin/CreateFormAdmin.tsx
+++ b/apps/frontend/src/pages/Adminpanel/subcomponents/CreateFormAdmin/CreateFormAdmin.tsx
@@ -147,7 +147,7 @@ const CreateFormAdmin = ({ returnToAdminpanel, searchAgain }: Props) => {
 					<label className={s.label_createFormAdmin}>
 						E-Mail Adresse*
 						<input
-							type='text'
+							type='email'
 							className={s.textinput_createFormAdmin}
 							onChange={e => setEmail(e.target.value)}
 							required
@@ -156,7 +156,7 @@ const CreateFormAdmin = ({ returnToAdminpanel, searchAgain }: Props) => {
 					<label className={s.label_createFormAdmin}>
 						Telefon
 						<input
-							type='text'
+							type='tel'
 							className={s.textinput_createFormAdmin}
 							onChange={e => setTelefon(e.target.value)}
 						/>

--- a/apps/frontend/src/pages/Adminpanel/subcomponents/EditFormAdmin/EditFormAdmin.tsx
+++ b/apps/frontend/src/pages/Adminpanel/subcomponents/EditFormAdmin/EditFormAdmin.tsx
@@ -158,7 +158,7 @@ const EditFormAdmin = ({
 					<label className={s.label_editFormAdmin}>
 						E-Mail Adresse*
 						<input
-							type='text'
+							type='email'
 							className={s.textinput_editFormAdmin}
 							onChange={e => setEmail(e.target.value)}
 							defaultValue={email}
@@ -168,7 +168,7 @@ const EditFormAdmin = ({
 					<label className={s.label_editFormAdmin}>
 						Telefon
 						<input
-							type='text'
+							type='tel'
 							className={s.textinput_editFormAdmin}
 							onChange={e => setTelefon(e.target.value)}
 							defaultValue={editData.telefon}

--- a/apps/frontend/src/pages/Profil/subcomponents/CreateDienstleister.tsx
+++ b/apps/frontend/src/pages/Profil/subcomponents/CreateDienstleister.tsx
@@ -150,7 +150,7 @@ const CreateDienstleister = ({ getDienstleisterOfUser }: Props) => {
 					<label className={s.label_createForm}>
 						E-Mail Adresse*
 						<input
-							type='text'
+							type='email'
 							className={s.textinput_createForm}
 							onChange={e => setEmail(e.target.value)}
 							required
@@ -159,7 +159,7 @@ const CreateDienstleister = ({ getDienstleisterOfUser }: Props) => {
 					<label className={s.label_createForm}>
 						Telefon
 						<input
-							type='text'
+							type='tel'
 							className={s.textinput_createForm}
 							onChange={e => setTelefon(e.target.value)}
 						/>

--- a/apps/frontend/src/pages/Profil/subcomponents/EditDeleteDienstleister.tsx
+++ b/apps/frontend/src/pages/Profil/subcomponents/EditDeleteDienstleister.tsx
@@ -189,7 +189,7 @@ const EditDeleteDienstleister = ({
 					<label className={s.label_editForm}>
 						E-Mail Adresse*
 						<input
-							type='text'
+							type='email'
 							className={s.textinput_editForm}
 							defaultValue={email}
 							onChange={e => setEmail(e.target.value)}
@@ -199,7 +199,7 @@ const EditDeleteDienstleister = ({
 					<label className={s.label_editForm}>
 						Telefon
 						<input
-							type='text'
+							type='tel'
 							className={s.textinput_editForm}
 							defaultValue={telefon}
 							onChange={e => setTelefon(e.target.value)}


### PR DESCRIPTION
Closes: [GPF-287](https://spacifik.atlassian.net/jira/software/projects/GPF/boards/3?selectedIssue=GPF-287)

## Comments
- Ich glaube URL als Datentyp für die Webseiten macht wahrscheinlich wenig Sinn, weil die Leute bestimmt auch gerne einfach sowas wie "Notar.de" schreiben, und dann bräuchte man den ganzen http:// Spaß auch. Andererseits müssten wir uns überlegen wie wir das später mit dem Ticket mit den klickbaren Websites machen wollen. Wahrscheinlich macht es dafür dann Sinn einheitlich die url zu bekommen damit wir sie einfach als Link kopieren können und nicht noch unterscheiden müssen wie genau die Website jetzt hingeschrieben wurde -> MEINUNGEN??

## Changes
- Create/Edit im Adminpanel und im Dienstleisterprofil haben jetzt für E-Mail und Telefon die entsprechenden Input Types "email" und "tel"
