### PR TITLE
[GPF-99] Fix missing li indicator in Safari

### DIFF
--- a/apps/frontend/src/pages/Index/Index.module.scss
+++ b/apps/frontend/src/pages/Index/Index.module.scss
@@ -47,13 +47,18 @@
 
 	li {
 		list-style-position: outside;
+		list-style-type: none;
+		padding-left: 1ch;
+		position: relative;
+
+		&::before {
+			content: "➔";
+			position: absolute;
+			transform: translateX(-2ch);
+		}
 
 		&:not(:last-child) {
 			margin-bottom: 1rem;
-		}
-
-		&::marker {
-			content: "➔ ";
 		}
 	}
 

--- a/packages/ui/src/styles/base.scss
+++ b/packages/ui/src/styles/base.scss
@@ -47,12 +47,15 @@ html,
 	}
 
 	li {
-		list-style: circle;
-		list-style-position: inside;
+		list-style-type: none;
 		margin-bottom: var(--size-04px);
+		position: relative;
+		padding-left: 2ch;
 
-		&::marker {
-			content: "➔ ";
+		&::before {
+			content: "➔";
+			position: absolute;
+			transform: translateX(-2ch);
 		}
 	}
 


### PR DESCRIPTION
[https://linear.app/venturecapitol/issue/GPF-99/missing-li-indicator-in-safari](https://linear.app/venturecapitol/issue/GPF-99/missing-li-indicator-in-safari)

Working: 
![image](https://user-images.githubusercontent.com/12611076/163626992-8f63b072-7505-465d-b06e-75964600d3e9.png)
